### PR TITLE
AppError - Custom Error class added

### DIFF
--- a/utils/AppError.js
+++ b/utils/AppError.js
@@ -1,0 +1,9 @@
+class AppError extends Error {
+    constructor(message, statusCode) {
+        super(message)  // Calls the constructor of the parent class (JS's built-in Error class)
+        this.statusCode = statusCode
+    }
+  }
+  
+  module.exports = AppError
+  


### PR DESCRIPTION
**Added AppError - Custom Error class - Extending JavaScript's built-in Error class**
- Accepts both `message` & `statusCode`.
- Easily assign status codes like `400`, `401`, `500`.
- Built-in `statusCode` property for consistent error handling.
- Standardized error responses across the app.